### PR TITLE
Add per-step workflow duration metric

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -17,6 +17,14 @@ var (
 	}
 	Metrics struct {
 		FetchWorkflowRunUsage bool
+		// FetchWorkflowStepMetrics, when true, fetches jobs for each completed
+		// run and emits per-step durations. Costs one extra API call per run,
+		// so scope it with WorkflowStepMetricsWorkflows.
+		FetchWorkflowStepMetrics bool
+		// WorkflowStepMetricsWorkflows optionally restricts step metrics to a
+		// comma-separated allowlist of workflow names. Empty means all workflows
+		// (high API cost + cardinality on a busy repo).
+		WorkflowStepMetricsWorkflows string
 	}
 	Port           int
 	Debug          bool
@@ -126,6 +134,20 @@ func InitConfiguration() []cli.Flag {
 			Value:       100 * 1024 * 1024,
 			Usage:       "Size of Github HTTP cache in bytes",
 			Destination: &Github.CacheSizeBytes,
+		},
+		&cli.BoolFlag{
+			Name:        "fetch_workflow_step_metrics",
+			EnvVars:     []string{"FETCH_WORKFLOW_STEP_METRICS"},
+			Usage:       "When true, performs an API call per completed run to emit per-step durations (github_workflow_step_duration_seconds)",
+			Value:       false,
+			Destination: &Metrics.FetchWorkflowStepMetrics,
+		},
+		&cli.StringFlag{
+			Name:        "workflow_step_metrics_workflows",
+			EnvVars:     []string{"WORKFLOW_STEP_METRICS_WORKFLOWS"},
+			Usage:       "Comma-separated allowlist of workflow names to emit step metrics for. Empty means all workflows.",
+			Value:       "",
+			Destination: &Metrics.WorkflowStepMetricsWorkflows,
 		},
 	}
 }

--- a/pkg/metrics/get_workflow_runs_from_github.go
+++ b/pkg/metrics/get_workflow_runs_from_github.go
@@ -103,6 +103,73 @@ func getRunUsage(owner string, repo string, runId int64) *github.WorkflowRunUsag
 	}
 }
 
+// getWorkflowJobs - list all jobs (with their steps) for a workflow run
+func getWorkflowJobs(owner string, repo string, runId int64) []*github.WorkflowJob {
+	opt := &github.ListWorkflowJobsOptions{
+		ListOptions: github.ListOptions{PerPage: 100},
+	}
+
+	var jobs []*github.WorkflowJob
+	for {
+		resp, rr, err := client.Actions.ListWorkflowJobs(context.Background(), owner, repo, runId, opt)
+		if rl_err, ok := err.(*github.RateLimitError); ok {
+			log.Printf("ListWorkflowJobs ratelimited. Pausing until %s", rl_err.Rate.Reset.Time.String())
+			time.Sleep(time.Until(rl_err.Rate.Reset.Time))
+			continue
+		} else if err != nil {
+			log.Printf("ListWorkflowJobs error for repo %s/%s and runId %d: %s", owner, repo, runId, err.Error())
+			return jobs
+		}
+
+		jobs = append(jobs, resp.Jobs...)
+		if rr.NextPage == 0 {
+			break
+		}
+		opt.Page = rr.NextPage
+	}
+
+	return jobs
+}
+
+// stepMetricsWorkflowAllowed reports whether step metrics should be emitted for
+// the given workflow name, honoring the optional allowlist.
+func stepMetricsWorkflowAllowed(workflow string) bool {
+	allow := strings.TrimSpace(config.Metrics.WorkflowStepMetricsWorkflows)
+	if allow == "" {
+		return true
+	}
+	for _, w := range strings.Split(allow, ",") {
+		if strings.TrimSpace(w) == workflow {
+			return true
+		}
+	}
+	return false
+}
+
+// emitWorkflowStepMetrics fetches the jobs of a completed run and sets a
+// per-step duration gauge for every step with both start and completion times.
+func emitWorkflowStepMetrics(owner string, repo string, run *github.WorkflowRun) {
+	workflow := getFieldValue(repo, *run, "workflow")
+	if !stepMetricsWorkflowAllowed(workflow) {
+		return
+	}
+	runId := strconv.FormatInt(run.GetID(), 10)
+	for _, job := range getWorkflowJobs(owner, repo, run.GetID()) {
+		for _, step := range job.Steps {
+			if step.StartedAt == nil || step.CompletedAt == nil {
+				continue
+			}
+			seconds := step.CompletedAt.Time.Sub(step.StartedAt.Time).Seconds()
+			if seconds < 0 {
+				continue
+			}
+			workflowStepDurationGauge.WithLabelValues(
+				repo, workflow, job.GetName(), step.GetName(), step.GetConclusion(), runId,
+			).Set(seconds)
+		}
+	}
+}
+
 // getWorkflowRunsFromGithub - return informations and status about a workflow
 func getWorkflowRunsFromGithub() {
 	for {
@@ -138,11 +205,16 @@ func getWorkflowRunsFromGithub() {
 				} else {
 					workflowRunDurationGauge.WithLabelValues(fields...).Set(float64(run_usage.GetRunDurationMS()))
 				}
+
+				if config.Metrics.FetchWorkflowStepMetrics && run.GetStatus() == "completed" {
+					emitWorkflowStepMetrics(r[0], r[1], run)
+				}
 			}
 		}
 
 		time.Sleep(time.Duration(config.Github.Refresh) * time.Second)
 		workflowRunStatusGauge.Reset()
 		workflowRunDurationGauge.Reset()
+		workflowStepDurationGauge.Reset()
 	}
 }

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -19,10 +19,11 @@ import (
 )
 
 var (
-	client                   *github.Client
-	err                      error
-	workflowRunStatusGauge   *prometheus.GaugeVec
-	workflowRunDurationGauge *prometheus.GaugeVec
+	client                    *github.Client
+	err                       error
+	workflowRunStatusGauge    *prometheus.GaugeVec
+	workflowRunDurationGauge  *prometheus.GaugeVec
+	workflowStepDurationGauge *prometheus.GaugeVec
 )
 
 // InitMetrics - register metrics in prometheus lib and start func for monitor
@@ -41,10 +42,18 @@ func InitMetrics() {
 		},
 		strings.Split(config.WorkflowFields, ","),
 	)
+	workflowStepDurationGauge = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "github_workflow_step_duration_seconds",
+			Help: "Per-step duration (in seconds) for jobs of completed workflow runs created in the last 12hr",
+		},
+		[]string{"repo", "workflow", "job", "step", "conclusion", "run_id"},
+	)
 	prometheus.MustRegister(runnersGauge)
 	prometheus.MustRegister(runnersOrganizationGauge)
 	prometheus.MustRegister(workflowRunStatusGauge)
 	prometheus.MustRegister(workflowRunDurationGauge)
+	prometheus.MustRegister(workflowStepDurationGauge)
 	prometheus.MustRegister(workflowBillGauge)
 	prometheus.MustRegister(runnersEnterpriseGauge)
 


### PR DESCRIPTION
## Summary

Adds a new metric so **per-step** workflow timings are observable. Today the exporter only emits run-level duration (`github_workflow_run_duration_ms`), so step latency — notably the "Initialize containers" step (the runner's job-container image pull) — is invisible to monitoring.

New gauge:

```
github_workflow_step_duration_seconds{repo, workflow, job, step, conclusion, run_id}
```

Set for every step (with both `started_at` and `completed_at`) of each **completed** run in the existing 12h window, following the same poll-and-reset pattern as the run gauges.

## Why gated + scoped

Fetching steps costs one extra `ListWorkflowJobs` API call per completed run, and step-level series are higher cardinality than run-level. So:

- `FETCH_WORKFLOW_STEP_METRICS` (bool, default **false**) — feature off unless explicitly enabled.
- `WORKFLOW_STEP_METRICS_WORKFLOWS` (comma list, default empty=all) — restrict to specific workflow names to bound API cost/cardinality on busy repos.

## Motivation

At Mixpanel, cold self-hosted-runner pods were spending 80–260s in "Initialize containers" (a stale image prepull), and there was no metric to detect or alert on it. With this metric you can chart step latency and alert, e.g.:

```promql
quantile(0.9, github_workflow_step_duration_seconds{workflow="Storybook", step="Initialize containers"})
```

## Test plan

- `go build ./...`, `go vet ./...`, `gofmt` clean on changed files.
- Enable with `FETCH_WORKFLOW_STEP_METRICS=true` and `WORKFLOW_STEP_METRICS_WORKFLOWS=Storybook`, confirm `github_workflow_step_duration_seconds` appears on `:9999/metrics` and API usage stays bounded.