### PR TITLE
Fix workflow cache key in step-duration metric (repo/workflow labels + allowlist)

### DIFF
--- a/pkg/metrics/get_workflow_runs_from_github.go
+++ b/pkg/metrics/get_workflow_runs_from_github.go
@@ -149,7 +149,14 @@ func stepMetricsWorkflowAllowed(workflow string) bool {
 // emitWorkflowStepMetrics fetches the jobs of a completed run and sets a
 // per-step duration gauge for every step with both start and completion times.
 func emitWorkflowStepMetrics(owner string, repo string, run *github.WorkflowRun) {
-	workflow := getFieldValue(repo, *run, "workflow")
+	// The workflow cache is keyed by the full "owner/name" (see periodicGithubFetcher),
+	// and the run-gauge path (getRelevantFields) looks it up that way. Use the same key
+	// here, otherwise getFieldValue misses the cache on every completed run: it logs
+	// "Couldn't fetch repo '<name>' from workflow cache." and falls back to "unknown",
+	// which also breaks the WorkflowStepMetricsWorkflows allowlist (nothing matches
+	// "unknown", so scoping the feature would emit zero step metrics).
+	fullRepo := owner + "/" + repo
+	workflow := getFieldValue(fullRepo, *run, "workflow")
 	if !stepMetricsWorkflowAllowed(workflow) {
 		return
 	}
@@ -163,8 +170,9 @@ func emitWorkflowStepMetrics(owner string, repo string, run *github.WorkflowRun)
 			if seconds < 0 {
 				continue
 			}
+			// Use fullRepo for the repo label too, to match github_workflow_run_* gauges.
 			workflowStepDurationGauge.WithLabelValues(
-				repo, workflow, job.GetName(), step.GetName(), step.GetConclusion(), runId,
+				fullRepo, workflow, job.GetName(), step.GetName(), step.GetConclusion(), runId,
 			).Set(seconds)
 		}
 	}


### PR DESCRIPTION
## What

Fixes a cache-key bug in `emitWorkflowStepMetrics` (added in #7).

`getWorkflowRunsFromGithub` iterates full repo names (`mixpanel/analytics`) and splits them into `r[0]`/`r[1]` for API calls. It passed the **short** name `r[1]` into `emitWorkflowStepMetrics`, which then called `getFieldValue(repo, ...)` — but the `workflows` cache is keyed by the **full** `owner/name` (see `periodicGithubFetcher`). So every completed run missed the cache.

## Symptoms in production

Deployed on `mixpanel/analytics` (all workflows), the exporter's stderr was ~99% this line — GKE tags it `severity=ERROR`, so Cloud Logging showed a wall of errors (800/800 in a 30-min sample):

```
Couldn't fetch repo 'analytics' from workflow cache.
```

Two more consequences of the same miss:

- **`workflow="unknown"` on every `github_workflow_step_duration_seconds` series** — the fallback value. The label the metric was added for is useless (e.g. the README's `...{workflow="Storybook", step="Initialize containers"}` example matches nothing).
- **`WORKFLOW_STEP_METRICS_WORKFLOWS` is silently broken** — the allowlist is matched against `"unknown"`, so scoping the feature (the recommended cost mitigation) emits **zero** step metrics. It only "works" today because the allowlist is empty.

The pre-existing `github_workflow_run_*` gauges are unaffected because `getRelevantFields` is called with the full repo name.

## Fix

Build the full `owner/name` inside `emitWorkflowStepMetrics` and use it for both the cache lookup and the `repo` label (so it also matches the run-level gauges, which use the full name).

This is **cardinality-neutral**: `workflow`/`repo` are functionally determined per series, so it's a 1:1 relabel — it corrects labels and eliminates the stderr flood without adding series.

## Test plan

- `gofmt -l` clean, `go build ./...`, `go vet ./...` pass.
- After deploy: `Couldn't fetch repo ... from workflow cache.` disappears; `github_workflow_step_duration_seconds` carries real `workflow` names and `repo="mixpanel/analytics"`; setting `WORKFLOW_STEP_METRICS_WORKFLOWS` to a workflow name emits only those steps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)